### PR TITLE
Correction overflow numéro équipe

### DIFF
--- a/js/championship.js
+++ b/js/championship.js
@@ -166,8 +166,7 @@ function display_current_ranking(ranking) {
 				<div class="ranking-rank">${team.classement}</div>
 				<div class="ranking-icon">${position_icon}</div>
 				<div class="ranking-name">
-					<div class="ranking-club">${team.club}</div>
-					${div_squad}
+					<div class="ranking-club">${team.club}${div_squad}</div>
 				</div>
 				<div>${team.matchs_joues}</div>
 				<div class="hidden-on-mobile">${team.matchs_gagnes}</div>

--- a/js/common.js
+++ b/js/common.js
@@ -89,15 +89,13 @@ function display_fixtures(games, main_class, favorite_club_name, page_club_name,
 				<div class="fixture-teams">
 					<div class="fixture-team">
 						<a class="fixture-team-name" href="../team/?club=${fixture.club_domicile}">
-							<div class="fixture-team-club">${fixture.club_domicile}</div>
-							${home_squad}
+							<div class="fixture-team-club">${fixture.club_domicile}${home_squad}</div>
 						</a>
 						${home_score}
 					</div>
 					<div class="fixture-team">
 						<a class="fixture-team-name" href="../team/?club=${fixture.club_exterieur}">
-							<div class="fixture-team-club">${fixture.club_exterieur}</div>
-							${away_squad}
+							<div class="fixture-team-club">${fixture.club_exterieur}${away_squad}</div>
 						</a>
 						${away_score}
 					</div>


### PR DESCRIPTION
[FIX] Correction de l'overflow du numéro d'équipe qui avait été cassé lors du changement de style d'affichage des numéros d'équipe. Modification faite pour les rencontres et pour le classement