### PR TITLE
Suppression des espaces à la fin du nom du club

### DIFF
--- a/scraper/functions.py
+++ b/scraper/functions.py
@@ -14,7 +14,7 @@ def get_team_squad(team_name):
 def get_team_club(team_name):
     team_club = re.sub(r' - [0-9]', '', team_name) # Suppression numéro d'équipe
     team_club = team_club.title() # Formattage majuscule
-    return team_club
+    return team_club.strip()
 
 # Obtenir le lien d'une équipe
 def get_team_link(link):


### PR DESCRIPTION
[FIX] Suppression des espaces à la fin du nom du club. Cela posait un problème lors de l'affichage de la page de l'équipe où le nom de l'équipe (sans espace) ne correspondait pas au nom de l'équipe dans le json (avec une espace à la fin)